### PR TITLE
Fix code scanning alert: DOM text reinterpreted as HTML

### DIFF
--- a/_includes/fellowship_sidebar.html
+++ b/_includes/fellowship_sidebar.html
@@ -8,7 +8,7 @@
 <!--<li><a href="/what/fellowships/apply" id="partners">APPLY NOW</a></li>-->
 </ul>
 
-<select id="fellowselect" onchange="window.location.assign(this.options[this.selectedIndex].value)">
+<select id="fellowselect" onchange="validateAndNavigate(this)">
   <option value="">learn about...</option>
   <option value="/what/fellowships">Fellowships</option>
   <option value="/what/fellowships/info">Program Details</option>
@@ -17,4 +17,21 @@
   <option value="/what/fellowships/partners">Fellowship Partners</option>
 <!--  <option value="/what/fellowships/apply">APPLY NOW</option> -->
 </select>
+<script>
+function validateAndNavigate(selectElement) {
+  const allowedUrls = [
+    "/what/fellowships",
+    "/what/fellowships/info",
+    "/what/fellowships/community",
+    "/what/fellowships/faq",
+    "/what/fellowships/partners"
+  ];
+  const selectedValue = selectElement.options[selectElement.selectedIndex].value;
+  if (allowedUrls.includes(selectedValue)) {
+    window.location.assign(selectedValue);
+  } else {
+    console.error("Invalid navigation attempt:", selectedValue);
+  }
+}
+</script>
 </div>


### PR DESCRIPTION
There is a code scanning alert related to file (_includes/fellowship_sidebar.html): DOM text reinterpreted as HTML

To fix the issue, we will validate the value of the selected <option> element before passing it to window.location.assign. Specifically, we will ensure that the value is one of the expected URLs from a predefined whitelist. This approach prevents any malicious or unexpected values from being used for navigation.

- Add a JavaScript function to validate the value against a whitelist of allowed URLs.
- Replace the inline onchange attribute with a call to this new function.
- Ensure the function is defined within the same file or included via a script tag.

After merging on my fork, this alert is resolved and vulnerability is patched.
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/e8c26998-0848-46ce-9d34-acff95d7769c" />
