### PR TITLE
refactor srccon Actions workflows to use Shared Actions v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,41 +3,40 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
     labels:
       - "dependencies"
       - "github-actions"
-    commit-message:
-      prefix: "ci"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "OpenNews/opennews-actions"
+        # Keep floating @v1 tag instead of pinning to specific versions
 
   # Bundler (Ruby dependencies)
   - package-ecosystem: "bundler"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
     labels:
       - "dependencies"
       - "ruby"
-    commit-message:
-      prefix: "deps"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
 
   # npm (JavaScript dependencies)
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
     labels:
       - "dependencies"
       - "javascript"
-    commit-message:
-      prefix: "deps"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 5
+    versioning-strategy: increase

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,173 +1,21 @@
 name: Deploy to S3
 
+permissions:
+  contents: read
+  id-token: write # Required for OIDC authentication to AWS
+  deployments: write # Required for creating/updating GitHub Deployments
+
 on:
   push:
     branches:
       - main
       - staging
 
-permissions:
-  contents: read
-  id-token: write # Required for OIDC authentication
-  deployments: write # Required for creating deployments
-
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ".ruby-version"
-          bundler-cache: true
-
-      - name: Validate YAML files
-        run: bundle exec rake validate_yaml
-
-      - name: Run configuration checks
-        run: bundle exec rake check
-
-      - name: Build Jekyll site
-        run: bundle exec rake build
-
-      - name: Run tests on built site
-        run: bundle exec rake test
-
-      - name: Extract deployment config from _config.yml
-        id: config
-        run: |
-          mapfile -t DEPLOYMENT_VALUES < <(ruby -ryaml -e "config = YAML.safe_load_file('_config.yml', permitted_classes: [], aliases: true); deployment = config['deployment'] || {}; puts deployment['bucket'].to_s; puts deployment['staging_bucket'].to_s; puts deployment['cloudfront_distribution_id'].to_s")
-          BUCKET="${DEPLOYMENT_VALUES[0]}"
-          if [ -z "$BUCKET" ]; then
-            echo "Error: S3 bucket name not configured. Please set deployment.bucket in _config.yml." >&2
-            exit 1
-          fi
-          STAGING_BUCKET="${DEPLOYMENT_VALUES[1]}"
-          if [ -z "$STAGING_BUCKET" ]; then
-            echo "Error: Staging bucket name not configured. Please set deployment.staging_bucket in _config.yml." >&2
-            exit 1
-          fi
-          CLOUDFRONT="${DEPLOYMENT_VALUES[2]}"
-          echo "bucket=$BUCKET" >> $GITHUB_OUTPUT
-          echo "staging_bucket=$STAGING_BUCKET" >> $GITHUB_OUTPUT
-          echo "cloudfront=$CLOUDFRONT" >> $GITHUB_OUTPUT
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-          role-session-name: Deploy-${{ github.event.repository.name }}-${{ github.run_id }}
-
-      - name: Create GitHub Deployment (Staging)
-        if: github.ref == 'refs/heads/staging'
-        id: deployment_staging
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.sha,
-              environment: 'staging',
-              description: `Deploy staging site to S3`,
-              auto_merge: false,
-              required_contexts: []
-            });
-            return deployment.data.id;
-
-      - name: Create GitHub Deployment (Production)
-        if: github.ref == 'refs/heads/main'
-        id: deployment_production
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.sha,
-              environment: 'production',
-              description: `Deploy production site to S3 and CloudFront`,
-              auto_merge: false,
-              required_contexts: []
-            });
-            return deployment.data.id;
-
-      - name: Deploy to S3 (Staging)
-        if: github.ref == 'refs/heads/staging'
-        run: |
-          aws s3 sync _site/ s3://${{ steps.config.outputs.staging_bucket }} \
-            --delete \
-            --cache-control "public, max-age=3600"
-
-      - name: Deploy to S3 (Production)
-        if: github.ref == 'refs/heads/main'
-        run: |
-          aws s3 sync _site/ s3://${{ steps.config.outputs.bucket }} \
-            --delete \
-            --cache-control "public, max-age=3600"
-
-      - name: Invalidate CloudFront (Production)
-        if: github.ref == 'refs/heads/main' && steps.config.outputs.cloudfront != ''
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ steps.config.outputs.cloudfront }} \
-            --paths "/*"
-
-      - name: Update Deployment Status (Staging Success)
-        if: github.ref == 'refs/heads/staging' && success()
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment_staging.outputs.result }},
-              state: 'success',
-              environment_url: 'http://${{ steps.config.outputs.staging_bucket }}.s3-website-us-east-1.amazonaws.com',
-              description: 'Staging deployment completed successfully'
-            });
-
-      - name: Update Deployment Status (Production Success)
-        if: github.ref == 'refs/heads/main' && success()
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment_production.outputs.result }},
-              state: 'success',
-              environment_url: 'https://opennews.org',
-              description: 'Production deployment completed successfully'
-            });
-
-      - name: Update Deployment Status (Staging Failure)
-        if: github.ref == 'refs/heads/staging' && failure() && steps.deployment_staging.outputs.result
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment_staging.outputs.result }},
-              state: 'failure',
-              description: 'Staging deployment failed'
-            });
-
-      - name: Update Deployment Status (Production Failure)
-        if: github.ref == 'refs/heads/main' && failure() && steps.deployment_production.outputs.result
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment_production.outputs.result }},
-              state: 'failure',
-              description: 'Production deployment failed'
-            });
+    uses: OpenNews/opennews-actions/.github/workflows/jekyll-deploy.yml@v1
+    with:
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+      production-url: https://www.opennews.org
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -3,7 +3,7 @@ name: Weekly Health Check
 on:
   schedule:
     - cron: "0 12 * * 1" # Every Monday at noon UTC
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,69 +11,4 @@ permissions:
 
 jobs:
   health-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ".ruby-version"
-          bundler-cache: true
-
-      - name: Check for outdated dependencies
-        run: |
-          echo "=== Checking for outdated gems ==="
-          bundle outdated || true
-
-      - name: Validate YAML files
-        run: bundle exec rake validate_yaml
-
-      - name: Build Jekyll site
-        run: bundle exec jekyll build --verbose
-
-      - name: Validate build output
-        run: |
-          if [ ! -d "_site" ]; then
-            echo "ERROR: _site directory not created"
-            exit 1
-          fi
-
-          if [ ! -f "_site/index.html" ]; then
-            echo "ERROR: index.html not found in _site"
-            exit 1
-          fi
-
-          echo "✅ Build validation passed"
-
-      - name: Create issue on failure
-        if: failure()
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const title = '🚨 Weekly health check failed';
-            const body = `The scheduled template validation failed on ${new Date().toISOString()}.
-
-            **Workflow Run:** ${context.payload.repository.html_url}/actions/runs/${context.runId}
-
-            Please investigate the failure and update dependencies as needed.`;
-
-            // Check if issue already exists
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'automated,health-check'
-            });
-
-            if (issues.data.length === 0) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['automated', 'health-check', 'bug']
-              });
-            }
+    uses: OpenNews/opennews-actions/.github/workflows/jekyll-health-check.yml@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,28 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Build & test
+        uses: OpenNews/opennews-actions/jekyll-build@v1
         with:
-          ruby-version: ".ruby-version"
-          bundler-cache: true
-
-      - name: Validate YAML files
-        run: bundle exec rake validate_yaml
-
-      - name: Build Jekyll site
-        run: bundle exec jekyll build --verbose
-
-      - name: Validate HTML and check links
-        run: |
-          bundle exec htmlproofer ./_site \
-            --disable-external \
-            --no-enforce-https \
-            --ignore-urls "/^http:\/\/(127\.0\.0\.1|0\.0\.0\.0|localhost|mitrakalita\.com)/" \
-            --allow-hash-href
+          run-checks: "true"
+          run-tests: "true"
 
       - name: Extract deployment config from _config.yml
         if: github.event_name == 'pull_request' && env.AWS_ROLE_ARN != ''

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
     ast (2.4.3)
@@ -181,7 +181,7 @@ DEPENDENCIES
 
 CHECKSUMS
   Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
-  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   async (2.37.0) sha256=e9d4b71f3509b44a3d2a19958101bf158dba975ba49a64a6934c8f0340ed989f

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
-    addressable (2.8.8)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
     ast (2.4.3)
-    async (2.36.0)
+    async (2.37.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -25,10 +25,11 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.18.0)
       ffi (>= 1.15.0)
+      logger
     eventmachine (1.2.7)
-    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
@@ -38,7 +39,7 @@ GEM
       bigdecimal
       rake (>= 13)
     hashery (2.1.2)
-    html-proofer (5.2.0)
+    html-proofer (5.2.1)
       addressable (~> 2.3)
       async (~> 2.1)
       benchmark (~> 0.5)
@@ -51,7 +52,7 @@ GEM
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    io-event (1.14.2)
+    io-event (1.14.3)
     jekyll (4.4.1)
       addressable (~> 2.4)
       base64 (~> 0.2)
@@ -77,7 +78,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.19.2)
+    json (2.19.3)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -92,7 +93,7 @@ GEM
     logger (1.7.0)
     mercenary (0.4.0)
     metrics (0.15.0)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.2)
@@ -108,7 +109,7 @@ GEM
       ttfunk
     prettier_print (1.2.1)
     prism (1.9.0)
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
@@ -160,8 +161,8 @@ GEM
     traces (0.18.2)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
-    typhoeus (1.5.0)
-      ethon (>= 0.9.0, < 0.16.0)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     unicode-display_width (2.6.0)
     webrick (1.9.2)
     yell (2.2.2)
@@ -180,10 +181,10 @@ DEPENDENCIES
 
 CHECKSUMS
   Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
-  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  async (2.36.0) sha256=090623f4c65706664355c9efa6c7bfb86771a513e65cd681c51cb27747530550
+  async (2.37.0) sha256=e9d4b71f3509b44a3d2a19958101bf158dba975ba49a64a6934c8f0340ed989f
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
@@ -192,24 +193,24 @@ CHECKSUMS
   console (1.34.3) sha256=869fbd74697efc4c606f102d2812b0b008e4e7fd738a91c591e8577140ec0dcc
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
-  ethon (0.15.0) sha256=0809805a035bc10f54162ca99f15ded49e428e0488bcfe1c08c821e18261a74d
+  ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
-  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
   google-protobuf (4.33.5-x86_64-linux-gnu) sha256=a782adf86bfba207740b49d7bb9ccdc25c4fb8f800fe222af62bce951149338a
   hashery (2.1.2) sha256=d239cc2310401903f6b79d458c2bbef5bf74c46f3f974ae9c1061fb74a404862
-  html-proofer (5.2.0) sha256=9d137cc437628b4dfc1191a9f80c5329dfb0a66b895aef021bf10758d80ec69d
+  html-proofer (5.2.1) sha256=fdd958a7cbf9c3255fb96fe7cfc4e611f64e2706e469488a3326309ad007d2fd
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  io-event (1.14.2) sha256=b0a069190eafe86005c22f7464f744971b5bd82f153740d34e6ab49548d4f613
+  io-event (1.14.3) sha256=c15cbbdd3b1cbf65bb87153a4c5bbc6d7dc07a357f6154601d5290f39ab2ac06
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
-  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
@@ -219,14 +220,14 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
   metrics (0.15.0) sha256=61ded5bac95118e995b1bc9ed4a5f19bc9814928a312a85b200abbdac9039072
-  nokogiri (1.19.1-x86_64-linux-gnu) sha256=1a4902842a186b4f901078e692d12257678e6133858d0566152fe29cdb98456a
+  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
   pdf-reader (2.15.1) sha256=18c6a986a84a3117fa49f4279fc2de51f5d2399b71833df5d2bccd595c7068ce
   prettier_print (1.2.1) sha256=a72838b5f23facff21f90a5423cdcdda19e4271092b41f4ea7f50b83929e6ff9
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
@@ -249,7 +250,7 @@ CHECKSUMS
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   ttfunk (1.8.0) sha256=a7cbc7e489cc46e979dde04d34b5b9e4f5c8f1ee5fc6b1a7be39b829919d20ca
-  typhoeus (1.5.0) sha256=120b67ed1ef515e6c0e938176db880f15b0916f038e78ce2a66290f3f1de3e3b
+  typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   yell (2.2.2) sha256=1d166f3cc3b6dc49a59778ea7156ed6d8de794c15106d48ffd6cbb061b9b26bc


### PR DESCRIPTION
This pull request refactors the repository's GitHub Actions workflows to use reusable workflows and composite actions from the `OpenNews/opennews-actions` repository. This change centralizes workflow logic, simplifies maintenance, and ensures consistency across CI/CD, health checks, and dependency management. In addition, the Dependabot configuration is updated to improve control over dependency updates and target the `staging` branch for PRs.

**Workflow Refactoring and Reuse:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R3-R21): Replaces the custom deploy workflow with a call to the reusable `jekyll-deploy.yml` workflow from `OpenNews/opennews-actions`, simplifying deployment logic and configuration.
* [`.github/workflows/health-check.yml`](diffhunk://#diff-0f4704320fbff1ffb2bb4c8e6618639b7acc0c55eda084cd70cffd33c1222d81L6-R14): Switches the health check workflow to use the shared `jekyll-health-check.yml` workflow, reducing local workflow complexity.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L22-R26): Replaces manual build and test steps with the `jekyll-build@v1` composite action, using its parameters to run checks and tests.

**Dependabot Configuration Improvements:**

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R6-R42): Updates to set `target-branch: staging` for all package ecosystems, limits open PRs, adjusts versioning strategy, and refines ignore rules for dependencies.